### PR TITLE
Feat(file_upload): Create an handler that can program a board via POST

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -38,6 +38,28 @@ func (c *connection) writer() {
 	c.ws.Close()
 }
 
+func uploadHandler(w http.ResponseWriter, r *http.Request) {
+	log.Print("Received a upload")
+	port := r.FormValue("port")
+	if port == "" {
+		http.Error(w, "port is required", http.StatusBadRequest)
+		return
+	}
+	board := r.FormValue("board")
+	if board == "" {
+		http.Error(w, "board is required", http.StatusBadRequest)
+		return
+	}
+	sketch, header, err := r.FormFile("sketch")
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+	}
+
+	path, err := saveFileonTempDir(header.Filename, sketch)
+
+	go spProgram(port, board, path)
+}
+
 func wsHandler(w http.ResponseWriter, r *http.Request) {
 	log.Print("Started a new websocket handler")
 	ws, err := websocket.Upgrade(w, r, nil, 1024, 1024)

--- a/download.go
+++ b/download.go
@@ -12,6 +12,34 @@ import (
 	"strings"
 )
 
+func saveFileonTempDir(filename string, sketch io.Reader) (path string, err error) {
+	// create tmp dir
+	tmpdir, err := ioutil.TempDir("", "serial-port-json-server")
+	if err != nil {
+		return "", errors.New("Could not create temp directory to store downloaded file. Do you have permissions?")
+	}
+
+	filename, _ = filepath.Abs(tmpdir + "/" + filename)
+
+	output, err := os.Create(filename)
+	if err != nil {
+		log.Println("Error while creating", filename, "-", err)
+		return filename, err
+	}
+	defer output.Close()
+
+	n, err := io.Copy(output, sketch)
+	if err != nil {
+		log.Println("Error while copying", err)
+		return filename, err
+	}
+
+	log.Println(n, "bytes saved")
+
+	return filename, nil
+
+}
+
 func downloadFromUrl(url string) (filename string, err error) {
 
 	// clean up url

--- a/main.go
+++ b/main.go
@@ -151,6 +151,7 @@ func main() {
 
 	http.HandleFunc("/", homeHandler)
 	http.HandleFunc("/ws", wsHandler)
+	http.HandleFunc("/upload", uploadHandler)
 	if err := http.ListenAndServe(*addr, nil); err != nil {
 		fmt.Printf("Error trying to bind to port: %v, so exiting...", err)
 		log.Fatal("Error ListenAndServe:", err)


### PR DESCRIPTION
The POST request needs a boad field, a port field and a sketch field
which is a file.

It returns an error if one of these is missing, or proceeds to save the
sketch and program the board.

The results of the board programming are sent via websocket as usual.
